### PR TITLE
Bugfix-134-change-width-demolition-scope-fit-3-visits

### DIFF
--- a/src/components/survey/survey-information.tsx
+++ b/src/components/survey/survey-information.tsx
@@ -293,6 +293,7 @@ const SurveyInformation: React.FC = () => {
     value: string,
     onChange: React.ChangeEventHandler<HTMLInputElement>
   ) => (
+    <Stack direction={"row"} spacing={2}>
     <WithDebounce
       name={ name }
       value={ value }
@@ -304,6 +305,14 @@ const SurveyInformation: React.FC = () => {
         </TextField>
       }
     />
+    {/*Temporary, showcases an upcoming feature*/}
+    <FormControlLabel 
+    sx={{width: "100%"}}
+    control={<Checkbox/>}
+    disabled
+    label={"Tämä purkukartoitus ei sisällä erillistä asbesti- ja haitta-aine-karkoitusta sekä -tutkimuksia."}
+    labelPlacement="start"/>
+    </Stack>
   );
 
   /**

--- a/src/components/survey/survey-information.tsx
+++ b/src/components/survey/survey-information.tsx
@@ -293,25 +293,26 @@ const SurveyInformation: React.FC = () => {
     value: string,
     onChange: React.ChangeEventHandler<HTMLInputElement>
   ) => (
-    <Stack direction={"row"} spacing={2}>
-    <WithDebounce
-      name={ name }
-      value={ value }
-      label={ label }
-      onChange={ onChange }
-      component={ props =>
-        <TextField select { ...props }>
-          { Object.values(SurveyType).map(renderDemolitionScopeOption) }
-        </TextField>
-      }
-    />
-    {/*Temporary, showcases an upcoming feature*/}
-    <FormControlLabel 
-    sx={{width: "100%"}}
-    control={<Checkbox/>}
-    disabled
-    label={"Tämä purkukartoitus ei sisällä erillistä asbesti- ja haitta-aine-karkoitusta sekä -tutkimuksia."}
-    labelPlacement="start"/>
+    <Stack direction="row" spacing={2}>
+      <WithDebounce
+        name={ name }
+        value={ value }
+        label={ label }
+        onChange={ onChange }
+        component={ props =>
+          <TextField select { ...props }>
+            { Object.values(SurveyType).map(renderDemolitionScopeOption) }
+          </TextField>
+        }
+      />
+      {/* Temporary, showcases an upcoming feature  */}
+      <FormControlLabel
+        sx={{ width: "100%" }}
+        control={<Checkbox/>}
+        disabled
+        label="Tämä purkukartoitus ei sisällä erillistä asbesti- ja haitta-aine-karkoitusta sekä -tutkimuksia."
+        labelPlacement="start"
+      />
     </Stack>
   );
 

--- a/src/components/survey/survey-information.tsx
+++ b/src/components/survey/survey-information.tsx
@@ -521,7 +521,7 @@ const SurveyInformation: React.FC = () => {
       {
         field: "reportDate",
         headerName: strings.survey.info.dataGridColumns.reportDate,
-        width: 325,
+        width: 148,
         type: "date",
         editable: true,
         renderEditCell: (params: GridRenderEditCellParams) => {
@@ -548,7 +548,7 @@ const SurveyInformation: React.FC = () => {
       {
         field: "visits",
         headerName: strings.survey.info.dataGridColumns.visits,
-        width: 200,
+        width: 250,
         editable: true
       }
     ];

--- a/src/components/survey/survey-information.tsx
+++ b/src/components/survey/survey-information.tsx
@@ -293,7 +293,7 @@ const SurveyInformation: React.FC = () => {
     value: string,
     onChange: React.ChangeEventHandler<HTMLInputElement>
   ) => (
-    <Stack direction="row" spacing={2}>
+    <Stack direction="row" spacing={ 2 }>
       <WithDebounce
         name={ name }
         value={ value }
@@ -308,7 +308,7 @@ const SurveyInformation: React.FC = () => {
       {/* Temporary, showcases an upcoming feature  */}
       <FormControlLabel
         sx={{ width: "100%" }}
-        control={<Checkbox/>}
+        control={ <Checkbox/> }
         disabled
         label="Tämä purkukartoitus ei sisällä erillistä asbesti- ja haitta-aine-karkoitusta sekä -tutkimuksia."
         labelPlacement="start"

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -361,8 +361,8 @@
         "role": "Rooli",
         "phone": "Puhelin",
         "email": "Sähköpostiosoite",
-        "reportDate": "Raportointipäivä",
-        "visits": "Käynnit"
+        "reportDate": "Raportointipvm",
+        "visits": "Kohdekäynnit"
       },
       "addNewSurveyorDialog": {
         "title": "Lisää kartoittaja"


### PR DESCRIPTION
Changed width of DemolitionScope by adding a temporary button that will be replaced by a new feature. Thats why I didn't do english translation part for it...

Changed the visits/report date width to fit three dates on screen and finnish translation 
Raportointipäivä --> Raportointipvm
Käynnit --> Kohdekäynnit
