### PR TITLE
translation changes in finnish and english

### DIFF
--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -179,7 +179,7 @@
       "building": "Building information",
       "otherStructures": "Other demolished structures",
       "info": "Survey information",
-      "reusables": "Reusable demolition Products",
+      "reusables": "Reusable demolition products",
       "waste": "Waste materials",
       "hazardous": "Hazardous materials",
       "attachments": "Attachments",

--- a/src/localization/en.json
+++ b/src/localization/en.json
@@ -179,7 +179,7 @@
       "building": "Building information",
       "otherStructures": "Other demolished structures",
       "info": "Survey information",
-      "reusables": "Reusable materials",
+      "reusables": "Reusable demolition Products",
       "waste": "Waste materials",
       "hazardous": "Hazardous materials",
       "attachments": "Attachments",
@@ -374,7 +374,7 @@
       }
     },
     "reusables": {
-      "title": "Reusable building parts",
+      "title": "Reusable demolition products",
       "dropFile": "Drop here",
       "viewImage": "View images",
       "moreImage": "More images",
@@ -392,7 +392,7 @@
         "usabilityHelperText": "If it's unknown, choose \"Not validated\"",
         "descriptionHelperText": "Free description, for example, location in the building.",
         "wasteAmountHelperText": "Optional",
-        "imageDescription": "Supported formats: jpg, gif or png\nMax. 4 pictures / building block"
+        "imageDescription": "Supported formats: jpg, gif or png\nMax. 2 pictures / building block"
       },
       "deleteReusableDialog": {
         "title": "Delete reusable building part",

--- a/src/localization/fi.json
+++ b/src/localization/fi.json
@@ -179,7 +179,7 @@
       "building": "Rakennuksen tiedot",
       "otherStructures": "Muut purettavat rakennukset / rakennelmat",
       "info": "Kartoituksen tiedot",
-      "reusables": "Uudelleenkäytettävät rakennusosat",
+      "reusables": "Uudelleenkäyttökelpoiset purkutuotteet",
       "waste": "Purkujätemateriaalit",
       "hazardous": "Haitta-ainetta sisältävät materiaalit",
       "attachments": "Liitteet",
@@ -391,7 +391,7 @@
         "usabilityHelperText": "Jos ei tiedossa, valitse \"ei arvioitu\"",
         "descriptionHelperText": "Vapaa kuvaus esim. sijainnista rakennuksessa tms.",
         "wasteAmountHelperText": "Valinnainen tieto",
-        "imageDescription": "Tuetut formaatit: jpg, gif tai png\nMax. 4 kuvaa / rakennusosa"
+        "imageDescription": "Tuetut formaatit: jpg, gif tai png\nMax. 2 kuvaa / rakennusosa"
       },
       "deleteReusableDialog": {
         "title": "Poista uudelleenkäytettävä osa",
@@ -438,7 +438,7 @@
       "dataGridColumns": {
         "material": "Materiaali",
         "wasteCode": "Jätekoodi",
-        "usage": "Jatkokäsittely",
+        "usage": "Käsittely",
         "amount": "Määrä",
         "amountInTons": "Määrä tonneina",
         "description": "Lisätiedot",


### PR DESCRIPTION
Changed texts and translations described in the issue: "Uudelleenkäyttökelpoiset purkutuotteet", "Käsittely" and "Max. 2 kuvaa / rakennusosa". Same changes in english.